### PR TITLE
ci: add repo-owned gate

### DIFF
--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -1,31 +1,3 @@
 #!/bin/sh
-# Pre-commit hook to prevent wrong lock files
-
-# Check for package-lock.json
-if [ -f "package-lock.json" ]; then
-    echo "❌ ERROR: package-lock.json detected!"
-    echo "This project uses pnpm. Please remove package-lock.json and use pnpm."
-    exit 1
-fi
-
-# Check for yarn.lock
-if [ -f "yarn.lock" ]; then
-    echo "❌ ERROR: yarn.lock detected!"
-    echo "This project uses pnpm. Please remove yarn.lock and use pnpm."
-    exit 1
-fi
-
-# Check if pnpm-lock.yaml exists
-if [ ! -f "pnpm-lock.yaml" ]; then
-    echo "⚠️  WARNING: pnpm-lock.yaml not found!"
-    echo "Please run 'pnpm install' to generate the lock file."
-fi
-
-# Check for node_modules in git
-if git ls-files --error-unmatch node_modules &> /dev/null; then
-    echo "❌ ERROR: node_modules should not be committed!"
-    echo "Please add node_modules to .gitignore"
-    exit 1
-fi
-
-exit 0
+# Optional local hook. GitHub Actions runs this same repo-owned gate.
+node tools/ci.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,27 +6,19 @@ on:
   pull_request:
     branches: [main, master]
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
-  validate:
+  gate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Validate HTML
-        run: |
-          if [ ! -f "index.html" ]; then
-            echo "❌ Error: index.html not found!"
-            exit 1
-          fi
-          echo "✅ index.html exists"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
 
-      - name: Check required files
-        run: |
-          files=("styles/main.css" "scripts/main.js" "favicon.ico")
-          for file in "${files[@]}"; do
-            if [ ! -f "$file" ]; then
-              echo "❌ Error: $file not found!"
-              exit 1
-            fi
-            echo "✅ $file exists"
-          done
+      - name: Run repo gate
+        run: node tools/ci.js

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ Static splash page for the Trump Goggles browser extension.
 ├── scripts/main.js # Scroll observer
 ├── api/health.js # Vercel health endpoint
 ├── api/canary/api/v1/errors.js # Browser error relay to Canary
+├── tools/ci.js # Local CI gate used by GitHub Actions
 ├── tools/verify-canary.js # Canary route verification
 ├── tools/smoke-canary-production.js # Production Canary smoke/readback
 └── favicon.ico
@@ -33,6 +34,9 @@ python3 -m http.server 3000
 
 # Verify Canary health and relay behavior
 node tools/verify-canary.js
+
+# Run the full local CI gate
+node tools/ci.js
 
 # Verify deployed Canary ingest and readback
 CANARY_READ_API_KEY=... node tools/smoke-canary-production.js

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ npx serve .
 # Verify Canary health and relay behavior
 node tools/verify-canary.js
 
+# Run the full local CI gate
+node tools/ci.js
+
 # After production deploy, verify Canary ingest and readback
 CANARY_READ_API_KEY=... node tools/smoke-canary-production.js
 ```
@@ -41,6 +44,7 @@ CANARY_READ_API_KEY=... node tools/smoke-canary-production.js
 │   ├── health.js
 │   └── canary/api/v1/errors.js
 ├── tools/
+│   ├── ci.js
 │   ├── verify-canary.js
 │   └── smoke-canary-production.js
 ├── favicon.ico

--- a/tools/ci.js
+++ b/tools/ci.js
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+'use strict';
+
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..');
+
+const REQUIRED_FILES = [
+  'index.html',
+  'styles/main.css',
+  'scripts/main.js',
+  'scripts/canary.js',
+  'api/health.js',
+  'api/canary/api/v1/errors.js',
+  'tools/verify-canary.js',
+  'tools/smoke-canary-production.js',
+  'favicon.ico',
+  'vercel.json',
+];
+
+const FORBIDDEN_DEPENDENCY_FILES = [
+  'package.json',
+  'package-lock.json',
+  'yarn.lock',
+  'pnpm-lock.yaml',
+  'bun.lock',
+  'bun.lockb',
+];
+
+function rootPath(relativePath) {
+  return path.join(ROOT, relativePath);
+}
+
+function requireFile(relativePath) {
+  const absolutePath = rootPath(relativePath);
+  if (!fs.existsSync(absolutePath) || !fs.statSync(absolutePath).isFile()) {
+    throw new Error(`missing required file: ${relativePath}`);
+  }
+}
+
+function readText(relativePath) {
+  return fs.readFileSync(rootPath(relativePath), 'utf8');
+}
+
+function listJavaScriptFiles(dir = ROOT) {
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .flatMap((entry) => {
+      const absolutePath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === '.git' || entry.name === 'node_modules') return [];
+        return listJavaScriptFiles(absolutePath);
+      }
+      if (!entry.isFile() || !entry.name.endsWith('.js')) return [];
+      return [path.relative(ROOT, absolutePath).split(path.sep).join(path.posix.sep)];
+    })
+    .sort();
+}
+
+function localReferencePath(reference, baseDir) {
+  const trimmed = reference.trim();
+  if (!trimmed || trimmed.startsWith('#')) return null;
+  if (trimmed.startsWith('//')) return null;
+  if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) return null;
+
+  const withoutHash = trimmed.split('#')[0];
+  const pathname = withoutHash.split('?')[0];
+  if (!pathname) return null;
+
+  const normalized = pathname.startsWith('/')
+    ? path.posix.normalize(pathname.slice(1))
+    : path.posix.normalize(path.posix.join(baseDir, pathname));
+
+  if (!normalized || normalized === '.') return null;
+  if (
+    normalized === '..' ||
+    normalized.startsWith('../') ||
+    path.posix.isAbsolute(normalized)
+  ) {
+    throw new Error(`local reference escapes repository root: ${reference}`);
+  }
+
+  return normalized;
+}
+
+function assertNoDependencyBuildStep() {
+  FORBIDDEN_DEPENDENCY_FILES.forEach((relativePath) => {
+    if (fs.existsSync(rootPath(relativePath))) {
+      throw new Error(`unexpected dependency/build metadata: ${relativePath}`);
+    }
+  });
+
+  const trackedNodeModules = spawnSync('git', ['ls-files', 'node_modules'], {
+    cwd: ROOT,
+    encoding: 'utf8',
+  });
+  if (trackedNodeModules.status === 0 && trackedNodeModules.stdout.trim()) {
+    throw new Error('node_modules is tracked by git');
+  }
+}
+
+function assertStaticVercelConfig() {
+  const config = JSON.parse(readText('vercel.json'));
+  if (config.framework !== null) {
+    throw new Error('vercel.json must keep framework set to null');
+  }
+  if (config.outputDirectory !== '.') {
+    throw new Error('vercel.json must keep outputDirectory set to "."');
+  }
+  if (config.buildCommand !== null && config.buildCommand !== '') {
+    throw new Error('vercel.json must not add a build command');
+  }
+}
+
+function assertHtmlReferences() {
+  const html = readText('index.html');
+  const ids = new Set();
+  for (const match of html.matchAll(/\sid=["']([^"']+)["']/g)) {
+    ids.add(match[1]);
+  }
+
+  for (const match of html.matchAll(/\s(href|src)=["']([^"']+)["']/g)) {
+    const [, attribute, value] = match;
+    if (attribute === 'href' && value.startsWith('#')) {
+      const id = value.slice(1);
+      if (id && !ids.has(id)) {
+        throw new Error(`missing in-page anchor target: ${value}`);
+      }
+      continue;
+    }
+
+    const localPath = localReferencePath(value, '');
+    if (localPath) requireFile(localPath);
+  }
+}
+
+function assertCssReferences() {
+  const cssFiles = ['styles/main.css'];
+  cssFiles.forEach((cssFile) => {
+    const baseDir = path.posix.dirname(cssFile);
+    const css = readText(cssFile);
+    for (const match of css.matchAll(/url\(\s*(['"]?)(.*?)\1\s*\)/g)) {
+      const localPath = localReferencePath(match[2], baseDir);
+      if (localPath) requireFile(localPath);
+    }
+  });
+}
+
+function assertJavaScriptSyntax() {
+  listJavaScriptFiles().forEach((relativePath) => {
+    const result = spawnSync(process.execPath, ['--check', relativePath], {
+      cwd: ROOT,
+      encoding: 'utf8',
+    });
+    if (result.status !== 0) {
+      process.stderr.write(result.stdout);
+      process.stderr.write(result.stderr);
+      throw new Error(`JavaScript syntax check failed: ${relativePath}`);
+    }
+  });
+}
+
+function runNodeScript(relativePath) {
+  const result = spawnSync(process.execPath, [relativePath], {
+    cwd: ROOT,
+    encoding: 'utf8',
+    stdio: 'pipe',
+  });
+
+  process.stdout.write(result.stdout);
+  process.stderr.write(result.stderr);
+
+  if (result.status !== 0) {
+    throw new Error(`command failed: node ${relativePath}`);
+  }
+}
+
+function step(name, fn) {
+  fn();
+  console.log(`[ok] ${name}`);
+}
+
+function main() {
+  step('required static files exist', () => REQUIRED_FILES.forEach(requireFile));
+  step('zero-dependency static-site contract is intact', assertNoDependencyBuildStep);
+  step('vercel static-host config is intact', assertStaticVercelConfig);
+  step('index.html local references resolve', assertHtmlReferences);
+  step('CSS local references resolve', assertCssReferences);
+  step('JavaScript parses', assertJavaScriptSyntax);
+  step('Canary routes preserve behavior', () => runNodeScript('tools/verify-canary.js'));
+  console.log('trump-goggles-splash CI gate passed');
+}
+
+main();


### PR DESCRIPTION
## Summary
- add a repo-owned Node CI gate for the static splash site
- make GitHub Actions and the tracked pre-commit hook call that same gate
- document the local gate for agent/human use

## Verification
- node tools/ci.js
- git diff --check
- actionlint .github/workflows/ci.yml
- thermo-nuclear review: no blockers

## Notes
The tracked hook is thin, but hook activation still depends on checkout hook setup. GitHub Actions is the hosted required proof surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new local verification check that helps catch common site and configuration issues before changes are merged.
  * Updated CI to use a single streamlined gate with improved pull request handling.

* **Documentation**
  * Expanded contributor docs to include the new verification step and updated project structure.

* **Chores**
  * Simplified commit-time checks to rely on the shared validation flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->