### PR TITLE
Restore Canary routes on DigitalOcean

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,23 @@ jobs:
 
       - name: Run repo gate
         run: node tools/ci.js
+
+      - name: Build and exercise DigitalOcean image
+        run: |
+          docker build -t trump-goggles-canary:ci .
+          docker run --detach --rm --name trump-goggles-canary \
+            --publish 127.0.0.1:8080:8080 \
+            --env CANARY_API_KEY=ci-placeholder \
+            --env CANARY_ENDPOINT=http://127.0.0.1:9 \
+            --env CANARY_SERVICE_NAME=trump-goggles-splash \
+            trump-goggles-canary:ci
+          trap 'docker stop trump-goggles-canary' EXIT
+          for attempt in $(seq 1 30); do
+            if curl --fail --silent --show-error \
+              http://127.0.0.1:8080/api/health > /tmp/health.json; then
+              break
+            fi
+            sleep 1
+          done
+          node -e "const h=require('/tmp/health.json'); if(h.status!=='ok'||h.dependencies.canary!=='configured') process.exit(1)"
+          test "$(curl --silent --output /dev/null --write-out '%{http_code}' http://127.0.0.1:8080/)" = 404

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:20.19.4-alpine3.22
+
+WORKDIR /app
+COPY --chown=node:node server.js ./server.js
+COPY --chown=node:node api ./api
+
+ENV NODE_ENV=production
+USER node
+EXPOSE 8080
+CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -53,13 +53,14 @@ CANARY_READ_API_KEY=... node tools/smoke-canary-production.js
 
 ## Observability
 
-Production deploys to Vercel. Canary observability requires the Vercel
-functions in `api/` or an equivalent server-side relay.
+Production deploys to DigitalOcean as a static site plus the dependency-free
+Node sidecar in `server.js`. Vercel remains a rollback surface during the
+migration soak. Both providers run the handlers in `api/`.
 
 Vercel production, preview, and development environments should define:
 
 - `CANARY_API_KEY` - service-bound ingest key for `trump-goggles-splash`
-- `CANARY_ENDPOINT` - defaults to `https://canary-obs.fly.dev`
+- `CANARY_ENDPOINT` - defaults to `https://canary.mistystep.io`
 - `CANARY_SERVICE_NAME` - defaults to `trump-goggles-splash`
 - `NEXT_PUBLIC_SITE_URL` - canonical origin, `https://www.trumpgoggles.com`
 

--- a/api/canary/api/v1/errors.js
+++ b/api/canary/api/v1/errors.js
@@ -1,5 +1,5 @@
 const DEFAULT_SERVICE = 'trump-goggles-splash';
-const DEFAULT_ENDPOINT = 'https://canary-obs.fly.dev';
+const DEFAULT_ENDPOINT = 'https://canary.mistystep.io';
 const DEFAULT_SITE_URL = 'https://www.trumpgoggles.com';
 const DEFAULT_SITE_ALIASES = ['https://trumpgoggles.com'];
 const MAX_BODY_BYTES = 32768;

--- a/api/health.js
+++ b/api/health.js
@@ -4,7 +4,7 @@ function canaryStatus() {
   return {
     status: process.env.CANARY_API_KEY ? 'configured' : 'not_configured',
     service: process.env.CANARY_SERVICE_NAME || DEFAULT_SERVICE,
-    endpoint: process.env.CANARY_ENDPOINT || 'https://canary-obs.fly.dev',
+    endpoint: process.env.CANARY_ENDPOINT || 'https://canary.mistystep.io',
   };
 }
 

--- a/server.js
+++ b/server.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+'use strict';
+
+const http = require('node:http');
+const health = require('./api/health');
+const relay = require('./api/canary/api/v1/errors');
+
+const routes = new Map([
+  ['/api/health', health],
+  ['/api/canary/api/v1/errors', relay],
+]);
+
+function adaptResponse(response) {
+  response.status = function status(code) {
+    this.statusCode = code;
+    return this;
+  };
+  response.json = function json(body) {
+    if (!this.hasHeader('Content-Type')) {
+      this.setHeader('Content-Type', 'application/json; charset=utf-8');
+    }
+    this.end(JSON.stringify(body));
+    return this;
+  };
+  return response;
+}
+
+const server = http.createServer(async (request, response) => {
+  const pathname = new URL(request.url, 'http://localhost').pathname;
+  const handler = routes.get(pathname);
+  if (!handler) {
+    response.writeHead(404, { 'Content-Type': 'application/json; charset=utf-8' });
+    response.end(JSON.stringify({ error: 'Not found' }));
+    return;
+  }
+
+  try {
+    await handler(request, adaptResponse(response));
+  } catch (error) {
+    console.error(
+      JSON.stringify({
+        level: 'error',
+        service: process.env.CANARY_SERVICE_NAME || 'trump-goggles-splash',
+        operation: 'request',
+        error: error instanceof Error ? error.message : 'unknown error',
+      })
+    );
+    if (!response.headersSent) {
+      response.writeHead(500, {
+        'Content-Type': 'application/json; charset=utf-8',
+      });
+    }
+    if (!response.writableEnded) {
+      response.end(JSON.stringify({ error: 'Internal server error' }));
+    }
+  }
+});
+
+const port = Number(process.env.PORT || 8080);
+server.listen(port, '0.0.0.0', () => {
+  console.log(
+    JSON.stringify({ level: 'info', service: 'trump-goggles-splash', port })
+  );
+});
+
+function shutdown() {
+  server.close(() => process.exit(0));
+}
+
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);

--- a/tools/ci.js
+++ b/tools/ci.js
@@ -14,7 +14,10 @@ const REQUIRED_FILES = [
   'scripts/canary.js',
   'api/health.js',
   'api/canary/api/v1/errors.js',
+  'server.js',
+  'Dockerfile',
   'tools/verify-canary.js',
+  'tools/verify-server.js',
   'tools/smoke-canary-production.js',
   'favicon.ico',
   'vercel.json',
@@ -190,6 +193,9 @@ function main() {
   step('CSS local references resolve', assertCssReferences);
   step('JavaScript parses', assertJavaScriptSyntax);
   step('Canary routes preserve behavior', () => runNodeScript('tools/verify-canary.js'));
+  step('DigitalOcean server adapter preserves behavior', () =>
+    runNodeScript('tools/verify-server.js')
+  );
   console.log('trump-goggles-splash CI gate passed');
 }
 

--- a/tools/smoke-canary-production.js
+++ b/tools/smoke-canary-production.js
@@ -5,7 +5,7 @@ const crypto = require('node:crypto');
 
 const SITE_URL = process.env.SITE_URL || 'https://www.trumpgoggles.com';
 const CANARY_ENDPOINT =
-  process.env.CANARY_ENDPOINT || 'https://canary-obs.fly.dev';
+  process.env.CANARY_ENDPOINT || 'https://canary.mistystep.io';
 const CANARY_SERVICE = process.env.CANARY_SERVICE_NAME || 'trump-goggles-splash';
 const READ_KEY =
   process.env.CANARY_READ_API_KEY ||

--- a/tools/verify-canary.js
+++ b/tools/verify-canary.js
@@ -51,6 +51,8 @@ async function verifyRelayRoute() {
   const relay = require('../api/canary/api/v1/errors');
   let forwarded;
 
+  delete process.env.CANARY_ENDPOINT;
+
   global.fetch = async (url, init) => {
     forwarded = { url, init, body: JSON.parse(init.body) };
     return new Response('{}', { status: 202 });

--- a/tools/verify-canary.js
+++ b/tools/verify-canary.js
@@ -89,7 +89,7 @@ async function verifyRelayRoute() {
   );
 
   assert.equal(response.statusCode, 202);
-  assert.equal(forwarded.url, 'https://canary-obs.fly.dev/api/v1/errors');
+  assert.equal(forwarded.url, 'https://canary.mistystep.io/api/v1/errors');
   assert.equal(forwarded.body.service, 'trump-goggles-splash');
   assert.equal(forwarded.body.message.includes('test@example.com'), false);
   assert.equal(forwarded.body.message.includes('Bearer abc123'), false);

--- a/tools/verify-server.js
+++ b/tools/verify-server.js
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const { spawn } = require('node:child_process');
+
+function listen(server) {
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve(server.address().port));
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+async function startApp(environment) {
+  const probe = http.createServer();
+  const port = await listen(probe);
+  await close(probe);
+
+  const child = spawn(process.execPath, ['server.js'], {
+    cwd: new URL('..', `file://${__dirname}/`).pathname,
+    env: {
+      ...process.env,
+      PORT: String(port),
+      NEXT_PUBLIC_SITE_URL: `http://127.0.0.1:${port}`,
+      ...environment,
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  let stderr = '';
+  child.stderr.on('data', (chunk) => {
+    stderr += chunk;
+  });
+
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    if (child.exitCode !== null) {
+      throw new Error(`server exited ${child.exitCode}: ${stderr}`);
+    }
+    try {
+      await fetch(`http://127.0.0.1:${port}/api/health`);
+      return { child, port };
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+  }
+
+  child.kill('SIGTERM');
+  throw new Error(`server did not become ready: ${stderr}`);
+}
+
+async function stopApp(child) {
+  child.kill('SIGTERM');
+  await new Promise((resolve) => child.once('exit', resolve));
+}
+
+async function main() {
+  let received;
+  const canary = http.createServer((request, response) => {
+    let body = '';
+    request.on('data', (chunk) => {
+      body += chunk;
+    });
+    request.on('end', () => {
+      received = {
+        authorization: request.headers.authorization,
+        body: JSON.parse(body),
+      };
+      response.writeHead(202, { 'Content-Type': 'application/json' });
+      response.end('{}');
+    });
+  });
+  const canaryPort = await listen(canary);
+
+  const { child, port } = await startApp({
+    CANARY_API_KEY: 'integration-test-key',
+    CANARY_ENDPOINT: `http://127.0.0.1:${canaryPort}`,
+    CANARY_SERVICE_NAME: 'trump-goggles-splash',
+    NODE_ENV: 'production',
+  });
+
+  try {
+    const health = await fetch(`http://127.0.0.1:${port}/api/health`);
+    assert.equal(health.status, 200);
+    assert.equal((await health.json()).dependencies.canary, 'configured');
+
+    const healthHead = await fetch(`http://127.0.0.1:${port}/api/health`, {
+      method: 'HEAD',
+    });
+    assert.equal(healthHead.status, 200);
+    assert.equal(await healthHead.text(), '');
+
+    const healthPost = await fetch(`http://127.0.0.1:${port}/api/health`, {
+      method: 'POST',
+    });
+    assert.equal(healthPost.status, 405);
+
+    const relayGet = await fetch(
+      `http://127.0.0.1:${port}/api/canary/api/v1/errors`
+    );
+    assert.equal(relayGet.status, 405);
+
+    const rejected = await fetch(
+      `http://127.0.0.1:${port}/api/canary/api/v1/errors`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Origin: 'https://evil.example',
+        },
+        body: JSON.stringify({ message: 'reject me' }),
+      }
+    );
+    assert.equal(rejected.status, 403);
+
+    const accepted = await fetch(
+      `http://127.0.0.1:${port}/api/canary/api/v1/errors`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Origin: `http://127.0.0.1:${port}`,
+          Referer: `http://127.0.0.1:${port}/?token=secret`,
+        },
+        body: JSON.stringify({
+          error_class: 'AdapterTest',
+          message: 'user test@example.com failed with token=secret',
+        }),
+      }
+    );
+    assert.equal(accepted.status, 202);
+    assert.equal(received.authorization, 'Bearer integration-test-key');
+    assert.equal(received.body.service, 'trump-goggles-splash');
+    assert.equal(received.body.message.includes('test@example.com'), false);
+    assert.equal(received.body.message.includes('token=secret'), false);
+
+    const missing = await fetch(`http://127.0.0.1:${port}/missing`);
+    assert.equal(missing.status, 404);
+  } finally {
+    await stopApp(child);
+    await close(canary);
+  }
+
+  console.log('trump-goggles DigitalOcean server adapter verification passed');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Outcome

Adds a dependency-free Node sidecar for `/api/health` and `/api/canary/api/v1/errors` so DigitalOcean preserves the incumbent Vercel functions.

## Verification

- `node tools/ci.js`
- `docker build -t trump-goggles-canary:test .`
- container `/api/health` returned `200` with Canary configured

## Deployment boundary

This PR does not change DNS, Vercel, or provider state. Vercel remains retained during the migration soak.

Agent: provider parity verifier
Agent-Surface: Codex CLI
Agent-Model: openai/gpt-5.5
Agent-Task: trump-goggles-provider-closeout
Agent-Context: run-cAhaGzEJx1Bg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a production-ready HTTP server with health and error-reporting endpoints.
  * Added containerized deployment support for Node.js applications.
  * Added graceful shutdown and structured error handling.

* **Bug Fixes**
  * Added consistent JSON responses for successful, unsupported, and failed requests.

* **Tests**
  * Added automated checks for endpoint behavior, request methods, authorization handling, and sensitive data protection.
  * CI now validates required deployment files and server behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->